### PR TITLE
Fix "more options" accessibility color.

### DIFF
--- a/chrome/Custom.css
+++ b/chrome/Custom.css
@@ -238,6 +238,11 @@
 	-webkit-animation: match-animation.5s ease-in-out;
 }
 
+/*-- MORE OPTIONS --*/
+#-webkit-web-inspector #toolbar-panels-menu {
+	color: #777;
+}
+
 /*-- INACTIVE SELECTORS --*/
 #-webkit-web-inspector .styles-section .properties .overloaded ,
 #-webkit-web-inspector .styles-section .properties .inactive ,


### PR DESCRIPTION
when the inspector is open on a relative small screen tabs are add to a "more option" button which is impossible to see nowadays.

the color applied on this pull request fix the issue making the button more accessible.
