### PR TITLE
Missing some informations

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,11 @@ Bundle 'zenorocha/dracula-theme'
 :BundleInstall
 ```
 
-If you aren't so clever just move the `vim/dracula.vim` file into `~/.vim/colors`.
+If you aren't so clever just move the `vim/dracula.vim` file into `~/.vim/colors` and add the following lines into your vimrc file:
+    
+    syntax on
+    color Dracula
+    
 
 ## Xcode
 


### PR DESCRIPTION
Missing some information in the traditional way to install color scheme in vim.
To activate numbers in traditional way, it's necessary to add `set number` too in vimrc file.
