### PR TITLE
tell Vim to use 256 colors

### DIFF
--- a/vim/dracula.vim
+++ b/vim/dracula.vim
@@ -13,6 +13,8 @@
 set background=dark
 highlight clear
 
+set t_Co=256
+
 if exists("syntax_on")
   syntax reset
 endif


### PR DESCRIPTION
Without this definition, the color scheme doesn't work in Tmux or another application running vim.
