### PR TITLE
Make compatible with atom-text-editor shadow DOM

### DIFF
--- a/index.less
+++ b/index.less
@@ -10,34 +10,43 @@
  * @author Zeno Rocha <hi@zenorocha.com>
  */
 
-.editor, .editor .gutter {
+.editor, .editor .gutter,
+:host, :host .gutter {
   background-color: #282a36;
   color: #f8f8f2;
 }
 
-.editor.is-focused .cursor {
+.editor.is-focused .cursor,
+:host(.is-focused) .cursor {
   border-color: #f8f8f0;
 }
 
-.editor.is-focused .selection .region {
+.editor.is-focused .selection .region,
+:host(.is-focused) .selection .region {
   background-color: #44475a;
 }
 
-.editor.is-focused .line-number.cursor-line-no-selection, .editor.is-focused .line.cursor-line {
+.editor.is-focused .line-number.cursor-line-no-selection, .editor.is-focused .line.cursor-line,
+:host(.is-focused) .line-number.cursor-line-no-selection, :host(.is-focused) .line.cursor-line {
   background-color: #44475a;
 }
 
-.editor .invisible-character {
+.editor .invisible-character,
+:host .invisible-character {
   color: #666;
 }
 
-.editor .indent-guide {
+.editor .indent-guide,
+:host .indent-guide {
   box-shadow: 1px 0 #444;
 }
 
 .editor .gutter .line-number.git-line-modified,
 .editor .gutter .line-number.git-line-removed,
-.editor .gutter .line-number.git-line-added {
+.editor .gutter .line-number.git-line-added,
+:host .gutter .line-number.git-line-modified,
+:host .gutter .line-number.git-line-removed,
+:host .gutter .line-number.git-line-added {
   border-left-width: 5px;
   padding-left: calc(0.5em - 5px);
 }


### PR DESCRIPTION
As discussed in our latest [blog post](http://blog.atom.io/2014/11/18/avoiding-style-pollution-with-the-shadow-dom.html), we'll be transitioning Atom's text editor to use the shadow DOM to avoid accidental styling conflicts. Since you have a really popular syntax theme, I thought I'd save you the trouble of reading through our [upgrade guide](https://atom.io/docs/v0.147.0/upgrading/upgrading-your-syntax-theme) and just make the changes for you. Please check to make sure everything works just in case I missed something specific to your theme, but this should be straightforward. Thanks!
