### PR TITLE
Display hyper as submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -22,9 +22,6 @@
 [submodule "highlightjs"]
 	path = highlightjs
 	url = https://github.com/dracula/highlightjs
-[submodule "hyper"]
-	path = hyper
-	url = https://github.com/dracula/hyper
 [submodule "iterm"]
 	path = iterm
 	url = https://github.com/dracula/iterm
@@ -103,3 +100,6 @@
 [submodule "zsh"]
 	path = zsh
 	url = https://github.com/dracula/zsh
+[submodule "hyper"]
+	path = hyper
+	url = https://github.com/dracula/hyper

--- a/.gitmodules
+++ b/.gitmodules
@@ -22,6 +22,9 @@
 [submodule "highlightjs"]
 	path = highlightjs
 	url = https://github.com/dracula/highlightjs
+[submodule "hyper"]
+	path = hyper
+	url = https://github.com/dracula/hyper
 [submodule "iterm"]
 	path = iterm
 	url = https://github.com/dracula/iterm

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ![Dracula](https://draculatheme.com/assets/img/dracula.gif)
 
-> A dark theme for [Atom](http://atom.io/), [Alfred](http://www.alfredapp.com/), [Emacs](https://www.gnu.org/software/emacs/), [Highlight.js](https://highlightjs.org/), [iTerm](http://www.iterm2.com/), [JetBrains](https://www.jetbrains.com/), [Pygments](http://pygments.org/), [Slack](http://slack.com), [Sublime Text](http://www.sublimetext.com/3), [TextMate](http://macromates.com/), [Terminal.app](http://www.apple.com/osx/apps), [Vim](http://www.vim.org/), [Xcode](https://itunes.apple.com/us/app/xcode/id497799835), [Zsh](http://www.zsh.org/) and many more.
+> A dark theme for [Atom](http://atom.io/), [Alfred](http://www.alfredapp.com/), [Emacs](https://www.gnu.org/software/emacs/), [Highlight.js](https://highlightjs.org/), [Hyper](https://hyper.is/), [iTerm](http://www.iterm2.com/), [JetBrains](https://www.jetbrains.com/), [Pygments](http://pygments.org/), [Slack](http://slack.com), [Sublime Text](http://www.sublimetext.com/3), [TextMate](http://macromates.com/), [Terminal.app](http://www.apple.com/osx/apps), [Vim](http://www.vim.org/), [Xcode](https://itunes.apple.com/us/app/xcode/id497799835), [Zsh](http://www.zsh.org/) and many more.
 
 ## Community
 Come visit on on Slack! [![Slack Status](https://slack.draculatheme.com/badge.svg)](https://slack.draculatheme.com)


### PR DESCRIPTION
## Hyper

- Update from `dracula-theme` repository
- Modify display `hyper` as submodule

