### PR TITLE
Add 256 color palette

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,20 +13,20 @@ All instructions can be found at [draculatheme.com](https://draculatheme.com/).
 
 ## Color Palette
 
-Palette      | Hex       | RGB           | HSL             | ![Color Picker Boxes](https://draculatheme.com/assets/img/color-boxes/eyedropper.png)
----          | ---       | ---           | ---             | ---
-Background   | `#282a36` | `40 42 54`    | `231° 15% 18%`  | ![Background Color](https://draculatheme.com/assets/img/color-boxes/background.png)
-Current Line | `#44475a` | `68 71 90`    | `232° 14% 31%`  | ![Current Line Color](https://draculatheme.com/assets/img/color-boxes/current_line.png)
-Selection    | `#44475a` | `68 71 90`    | `232° 14% 31%`  | ![Selection Color](https://draculatheme.com/assets/img/color-boxes/selection.png)
-Foreground   | `#f8f8f2` | `248 248 242` | `60° 30% 96%`   | ![Foreground Color](https://draculatheme.com/assets/img/color-boxes/foreground.png)
-Comment      | `#6272a4` | `98 114 164`  | `225° 27% 51%`  | ![Comment Color](https://draculatheme.com/assets/img/color-boxes/comment.png)
-Cyan         | `#8be9fd` | `139 233 253` | `191° 97% 77%`  | ![Cyan Color](https://draculatheme.com/assets/img/color-boxes/cyan.png)
-Green        | `#50fa7b` | `80 250 123`  | `135° 94% 65%`  | ![Green Color](https://draculatheme.com/assets/img/color-boxes/green.png)
-Orange       | `#ffb86c` | `255 184 108` | `31° 100% 71%`  | ![Orange Color](https://draculatheme.com/assets/img/color-boxes/orange.png)
-Pink         | `#ff79c6` | `255 121 198` | `326° 100% 74%` | ![Pink Color](https://draculatheme.com/assets/img/color-boxes/pink.png)
-Purple       | `#bd93f9` | `189 147 249` | `265° 89% 78%`  | ![Purple Color](https://draculatheme.com/assets/img/color-boxes/purple.png)
-Red          | `#ff5555` | `255 85 85`   | `0° 100% 67%`   | ![Red Color](https://draculatheme.com/assets/img/color-boxes/red.png)
-Yellow       | `#f1fa8c` | `241 250 140` | `65° 92% 76%`   | ![Yellow Color](https://draculatheme.com/assets/img/color-boxes/yellow.png)
+Palette      | 256   | Hex       | RGB           | HSL             | ![Color Picker Boxes](https://draculatheme.com/assets/img/color-boxes/eyedropper.png)
+---          | ---   | ---       | ---           | ---             | ---
+Background   | `16`  | `#282a36` | `40 42 54`    | `231° 15% 18%`  | ![Background Color](https://draculatheme.com/assets/img/color-boxes/background.png)
+Current Line | `236` | `#44475a` | `68 71 90`    | `232° 14% 31%`  | ![Current Line Color](https://draculatheme.com/assets/img/color-boxes/current_line.png)
+Selection    | `236` | `#44475a` | `68 71 90`    | `232° 14% 31%`  | ![Selection Color](https://draculatheme.com/assets/img/color-boxes/selection.png)
+Foreground   | `231` | `#f8f8f2` | `248 248 242` | `60° 30% 96%`   | ![Foreground Color](https://draculatheme.com/assets/img/color-boxes/foreground.png)
+Comment      | `61`  | `#6272a4` | `98 114 164`  | `225° 27% 51%`  | ![Comment Color](https://draculatheme.com/assets/img/color-boxes/comment.png)
+Cyan         | `117` | `#8be9fd` | `139 233 253` | `191° 97% 77%`  | ![Cyan Color](https://draculatheme.com/assets/img/color-boxes/cyan.png)
+Green        | `84`  | `#50fa7b` | `80 250 123`  | `135° 94% 65%`  | ![Green Color](https://draculatheme.com/assets/img/color-boxes/green.png)
+Orange       | `215` | `#ffb86c` | `255 184 108` | `31° 100% 71%`  | ![Orange Color](https://draculatheme.com/assets/img/color-boxes/orange.png)
+Pink         | `212` | `#ff79c6` | `255 121 198` | `326° 100% 74%` | ![Pink Color](https://draculatheme.com/assets/img/color-boxes/pink.png)
+Purple       | `141` | `#bd93f9` | `189 147 249` | `265° 89% 78%`  | ![Purple Color](https://draculatheme.com/assets/img/color-boxes/purple.png)
+Red          | `210` | `#ff5555` | `255 85 85`   | `0° 100% 67%`   | ![Red Color](https://draculatheme.com/assets/img/color-boxes/red.png)
+Yellow       | `228` | `#f1fa8c` | `241 250 140` | `65° 92% 76%`   | ![Yellow Color](https://draculatheme.com/assets/img/color-boxes/yellow.png)
 
 ## FAQ
 


### PR DESCRIPTION
I've been working on a theme for Mutt and figured it might be helpful to include a 256 color palette in the README; this will be particularly handy for theming terminal applications and will save people having to figure it out like I did. I've added the palette to the first column as the current order seems to be basic (hex) -> complex (HSL).

The following script can display the colors in a terminal for validation:
```
#!/usr/bin/env bash

for i in {16,236,231,61,117,84,215,212,141,210,228}; do
    printf "\x1b[38;5;${i}mcolour${i}\n"
done
```
