### PR TITLE
Add ghostwriter to .gitmodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -91,6 +91,9 @@
 [submodule "gedit"]
 	path = themes/gedit
 	url = https://github.com/dracula/gedit
+[submodule "ghostwriter"]
+	path = themes/ghostwriter
+	url = https://github.com/dracula/ghostwriter
 [submodule "gh-pages"]
 	path = themes/gh-pages
 	url = https://github.com/dracula/gh-pages


### PR DESCRIPTION
I have just created Dracula theme for Markdown Editor ghostwriter at [dracula-ghostwriter](https://github.com/totoroot/dracula-ghostwriter) and opened issue #550. As soon as @zenorocha has merged the changes, I can add the submodule and update this PR.